### PR TITLE
Advanced vault registry NFTs

### DIFF
--- a/src/VaultRegistry.sol
+++ b/src/VaultRegistry.sol
@@ -25,6 +25,9 @@ contract VaultRegistry is IVaultRegistry, EIP1967Admin, ERC721Enumerable {
         string memory baseURI_
     ) ERC721(name_, symbol_, baseURI_) {}
 
+    /// @notice Enables/disables new Vault Registry NFT minter
+    /// @param minter address of the modified minter
+    /// @param approved true, to enable minter, false otherwise
     function setMinter(address minter, bool approved) external onlyAdmin {
         isMinter[minter] = approved;
     }

--- a/src/VaultRegistry.sol
+++ b/src/VaultRegistry.sol
@@ -2,55 +2,57 @@
 pragma solidity 0.8.15;
 
 import "@zkbob/proxy/EIP1967Admin.sol";
-import "./interfaces/ICDP.sol";
 import "./token/ERC721/ERC721Enumerable.sol";
+import "./interfaces/IVaultRegistry.sol";
 
-contract VaultRegistry is EIP1967Admin, ERC721Enumerable {
+contract VaultRegistry is IVaultRegistry, EIP1967Admin, ERC721Enumerable {
     /// @notice Thrown when not minter trying to mint
     error Forbidden();
 
-    /// @notice Thrown when user trying to burn nft and has non-empty collateral
-    error NonEmptyCollateral();
+    /// @notice CDP Vault contracts allowed to mint
+    mapping(address => bool) public isMinter;
 
-    /// @notice CDP contract allowed to mint
-    ICDP immutable cdp;
+    /// @notice Vault NFT minter
+    mapping(uint256 => address) public minterOf;
 
     /// @notice Creates a new contract
-    /// @param cdp_ CDP contract allowed to mint
     /// @param name_ Token name
     /// @param symbol_ Token's symbol name
     /// @param baseURI_ Token's baseURI
     constructor(
-        ICDP cdp_,
         string memory name_,
         string memory symbol_,
         string memory baseURI_
-    ) ERC721(name_, symbol_, baseURI_) {
-        cdp = cdp_;
+    ) ERC721(name_, symbol_, baseURI_) {}
+
+    function setMinter(address minter, bool approved) external onlyAdmin {
+        isMinter[minter] = approved;
     }
 
-    /// @notice Mints a new token
-    /// @param to Token receiver
-    /// @param tokenId Id of a token
-    function mint(address to, uint256 tokenId) external {
-        if (msg.sender != address(cdp)) {
+    /// @inheritdoc IVaultRegistry
+    function isAuthorized(uint256 tokenId, address user) external view returns (bool) {
+        return _isApprovedOrOwner(user, tokenId);
+    }
+
+    /// @inheritdoc IVaultRegistry
+    function mint(address to) external returns (uint256 tokenId) {
+        if (!isMinter[msg.sender]) {
             revert Forbidden();
         }
+
+        tokenId = totalSupply() + 1;
+        minterOf[tokenId] = msg.sender;
+
         _mint(to, tokenId);
     }
 
-    /// @notice Burns an existent token
-    /// @param tokenId Id of a token
+    /// @inheritdoc IVaultRegistry
     function burn(uint256 tokenId) external {
-        if (msg.sender != ownerOf(tokenId)) {
+        if (msg.sender != minterOf[tokenId]) {
             revert Forbidden();
         }
 
-        uint256[] memory vaultNfts = cdp.vaultNftsById(tokenId);
-
-        if (vaultNfts.length != 0) {
-            revert NonEmptyCollateral();
-        }
+        delete minterOf[tokenId];
 
         _burn(tokenId);
     }

--- a/src/interfaces/ICDP.sol
+++ b/src/interfaces/ICDP.sol
@@ -89,4 +89,15 @@ interface ICDP {
     /// @notice Liquidate a vault
     /// @param vaultId Id of the vault subject to liquidation
     function liquidate(uint256 vaultId) external;
+
+    /// @notice Withdraws vault owed tokens, left after liquidation
+    /// @param vaultId id of the liquidated vault
+    /// @param to address where to sent withdrawn tokens
+    /// @param maxAmount max amount of tokens to withdraw
+    /// @return withdrawnAmount final amount of withdrawn tokens
+    function withdrawOwed(
+        uint256 vaultId,
+        address to,
+        uint256 maxAmount
+    ) external returns (uint256 withdrawnAmount);
 }

--- a/src/interfaces/IVaultRegistry.sol
+++ b/src/interfaces/IVaultRegistry.sol
@@ -17,6 +17,7 @@ interface IVaultRegistry is IERC721Enumerable {
     function mint(address to) external returns (uint256);
 
     /// @notice Burns an existent token
+    /// Only the minter of the specified token id is allowed to burn it
     /// @param tokenId Id of a token
     function burn(uint256 tokenId) external;
 }

--- a/src/interfaces/IVaultRegistry.sol
+++ b/src/interfaces/IVaultRegistry.sol
@@ -4,10 +4,17 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 
 interface IVaultRegistry is IERC721Enumerable {
+    /// @notice Checks if user is authorized to manage specific token id
+    /// Only token owner or approved operators are allowed to manage a specific token id
+    /// @param tokenId Id of a token
+    /// @param user Address of the manager
+    /// @return true if user is authorized, false otherwise
+    function isAuthorized(uint256 tokenId, address user) external view returns (bool);
+
     /// @notice Mints a new token
     /// @param to Token receiver
-    /// @param tokenId Id of a token
-    function mint(address to, uint256 tokenId) external;
+    /// @return minted token id
+    function mint(address to) external returns (uint256);
 
     /// @notice Burns an existent token
     /// @param tokenId Id of a token

--- a/src/script/AbstractDeployment.sol
+++ b/src/script/AbstractDeployment.sol
@@ -75,10 +75,11 @@ abstract contract AbstractDeployment is ConfigContract {
 
         recordDeployedContract("Vault", address(vault));
 
-        VaultRegistry vaultRegistry = new VaultRegistry(ICDP(address(vault)), "BOB Vault Token", "BVT", "");
+        VaultRegistry vaultRegistry = new VaultRegistry("BOB Vault Token", "BVT", "");
 
         EIP1967Proxy vaultRegistryProxy = new EIP1967Proxy(msg.sender, address(vaultRegistry), "");
         vaultRegistry = VaultRegistry(address(vaultRegistryProxy));
+        vaultRegistry.setMinter(address(vault), true);
 
         vault.setVaultRegistry(IVaultRegistry(address(vaultRegistry)));
 

--- a/test/AbstractIntegration.t.sol
+++ b/test/AbstractIntegration.t.sol
@@ -38,11 +38,16 @@ abstract contract AbstractIntegrationTestForVault is SetupContract, AbstractFork
 
         token = new BobTokenMock();
 
+        vaultRegistry = new VaultRegistry("BOB Vault Token", "BVT", "");
+        vaultRegistryProxy = new EIP1967Proxy(address(this), address(vaultRegistry), "");
+        vaultRegistry = VaultRegistry(address(vaultRegistryProxy));
+
         vault = new Vault(
             INonfungiblePositionManager(PositionManager),
             INFTOracle(address(nftOracle)),
             treasury,
-            address(token)
+            address(token),
+            address(vaultRegistry)
         );
 
         bytes memory initData = abi.encodeWithSelector(
@@ -54,13 +59,7 @@ abstract contract AbstractIntegrationTestForVault is SetupContract, AbstractFork
         vaultProxy = new EIP1967Proxy(address(this), address(vault), initData);
         vault = Vault(address(vaultProxy));
 
-        vaultRegistry = new VaultRegistry("BOB Vault Token", "BVT", "");
-
-        vaultRegistryProxy = new EIP1967Proxy(address(this), address(vaultRegistry), "");
-        vaultRegistry = VaultRegistry(address(vaultRegistryProxy));
         vaultRegistry.setMinter(address(vault), true);
-
-        vault.setVaultRegistry(IVaultRegistry(address(vaultRegistry)));
 
         token.updateMinter(address(vault), true, true);
         token.approve(address(vault), type(uint256).max);

--- a/test/AbstractIntegration.t.sol
+++ b/test/AbstractIntegration.t.sol
@@ -54,10 +54,11 @@ abstract contract AbstractIntegrationTestForVault is SetupContract, AbstractFork
         vaultProxy = new EIP1967Proxy(address(this), address(vault), initData);
         vault = Vault(address(vaultProxy));
 
-        vaultRegistry = new VaultRegistry(ICDP(address(vault)), "BOB Vault Token", "BVT", "");
+        vaultRegistry = new VaultRegistry("BOB Vault Token", "BVT", "");
 
         vaultRegistryProxy = new EIP1967Proxy(address(this), address(vaultRegistry), "");
         vaultRegistry = VaultRegistry(address(vaultRegistryProxy));
+        vaultRegistry.setMinter(address(vault), true);
 
         vault.setVaultRegistry(IVaultRegistry(address(vaultRegistry)));
 
@@ -76,6 +77,8 @@ abstract contract AbstractIntegrationTestForVault is SetupContract, AbstractFork
         address[] memory depositors = new address[](1);
         depositors[0] = address(this);
         vault.addDepositorsToAllowlist(depositors);
+
+        skip(1 days);
     }
 
     // integration scenarios

--- a/test/AbstractVaultRegistry.t.sol
+++ b/test/AbstractVaultRegistry.t.sol
@@ -32,11 +32,16 @@ abstract contract AbstractVaultRegistryTest is Test, SetupContract, AbstractFork
 
         token = new BobTokenMock();
 
+        vaultRegistry = new VaultRegistry("BOB Vault Token", "BVT", "baseURI/");
+        vaultRegistryProxy = new EIP1967Proxy(address(this), address(vaultRegistry), "");
+        vaultRegistry = VaultRegistry(address(vaultRegistryProxy));
+
         vault = new Vault(
             INonfungiblePositionManager(PositionManager),
             INFTOracle(address(nftOracle)),
             treasury,
-            address(token)
+            address(token),
+            address(vaultRegistry)
         );
 
         bytes memory initData = abi.encodeWithSelector(
@@ -48,13 +53,7 @@ abstract contract AbstractVaultRegistryTest is Test, SetupContract, AbstractFork
         vaultProxy = new EIP1967Proxy(address(this), address(vault), initData);
         vault = Vault(address(vaultProxy));
 
-        vaultRegistry = new VaultRegistry("BOB Vault Token", "BVT", "baseURI/");
-
-        vaultRegistryProxy = new EIP1967Proxy(address(this), address(vaultRegistry), "");
-        vaultRegistry = VaultRegistry(address(vaultRegistryProxy));
         vaultRegistry.setMinter(address(vault), true);
-
-        vault.setVaultRegistry(IVaultRegistry(address(vaultRegistry)));
 
         token.approve(address(vault), type(uint256).max);
 


### PR DESCRIPTION
## Changelog
* Allow sharing of VaultRegistry contract between multiple independent Vault contracts
* Replace `vault.tokenCount()` with `vaultRegistry.totalSupply()`
* Allow approved entities to perform vault operations on behalf of the user (`ERC721.setApprovalForAll(...)`, `ERC721.approve(...)`)
* `burnVault` in vault contract
* Allow anyone to burn other user's debt
* Replace direct owner tokens transfer on liquidation with `vaultOwed` accumulator
* Make `vaultRegistry` immutable