### PR TITLE
Added minimal position width for each pool

### DIFF
--- a/src/interfaces/ICDP.sol
+++ b/src/interfaces/ICDP.sol
@@ -51,6 +51,10 @@ interface ICDP {
     /// @return uint256 Total debt value (in MUSD weis)
     function getOverallDebt(uint256 vaultId) external view returns (uint256);
 
+    /// @notice Get minimal position's width for the pool
+    /// @param pool The address of the pool
+    function minimalWidth(address pool) external view returns (uint24);
+
     // -------------------  EXTERNAL, MUTATING  -------------------
 
     /// @notice Change liquidation fee (multiplied by DENOMINATOR) to a given value
@@ -80,6 +84,11 @@ interface ICDP {
     /// @notice Revoke a pool from the whitelist
     /// @param pool Address of the revoked whitelisted pool
     function revokeWhitelistedPool(address pool) external;
+
+    /// @notice Changes a minimal position's width for the pool
+    /// @param pool Address of the pool
+    /// @param width The new minimal width
+    function changeMinimalWidth(address pool, uint24 width) external;
 
     /// @notice Set liquidation threshold (multiplied by DENOMINATOR) for a given pool
     /// @param pool Address of the pool

--- a/src/interfaces/oracles/INFTOracle.sol
+++ b/src/interfaces/oracles/INFTOracle.sol
@@ -6,6 +6,7 @@ interface INFTOracle {
     /// @param nft The token id of the position
     /// @return deviationSafety True if price deviation is safe, False otherwise
     /// @return positionAmount The value of the given position
+    /// @return width The width of the position (in ticks)
     /// @return pool Address of the position's pool
     function price(uint256 nft)
         external
@@ -13,6 +14,7 @@ interface INFTOracle {
         returns (
             bool deviationSafety,
             uint256 positionAmount,
+            uint24 width,
             address pool
         );
 

--- a/src/oracles/QuickswapV3Oracle.sol
+++ b/src/oracles/QuickswapV3Oracle.sol
@@ -61,6 +61,7 @@ contract QuickswapV3Oracle is INFTOracle, Ownable {
         returns (
             bool deviationSafety,
             uint256 positionAmount,
+            uint24 width,
             address pool
         )
     {
@@ -72,6 +73,7 @@ contract QuickswapV3Oracle is INFTOracle, Ownable {
 
         uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(info.tickLower);
         uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(info.tickUpper);
+        width = uint24(info.tickUpper - info.tickLower);
 
         uint256[2] memory tokenAmounts;
         uint256[2] memory pricesX96;

--- a/src/oracles/UniV3Oracle.sol
+++ b/src/oracles/UniV3Oracle.sol
@@ -60,6 +60,7 @@ contract UniV3Oracle is INFTOracle, Ownable {
         returns (
             bool deviationSafety,
             uint256 positionAmount,
+            uint24 width,
             address pool
         )
     {
@@ -70,6 +71,7 @@ contract UniV3Oracle is INFTOracle, Ownable {
 
         uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(info.tickLower);
         uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(info.tickUpper);
+        width = uint24(info.tickUpper - info.tickLower);
 
         uint256[2] memory tokenAmounts;
         uint256[2] memory pricesX96;

--- a/test/AbstractNftOracle.t.sol
+++ b/test/AbstractNftOracle.t.sol
@@ -23,29 +23,29 @@ abstract contract AbstractNftOracleTest is SetupContract, AbstractForkTest, Abst
         // One side
         nftOracle.price(nft);
         helper.setTokenPrice(oracle, weth, uint256(1500 << 96));
-        (, uint256 oldPrice, ) = nftOracle.price(nft);
+        (, uint256 oldPrice, , ) = nftOracle.price(nft);
         helper.setTokenPrice(oracle, weth, uint256(1700 << 96));
-        (, uint256 newPrice, ) = nftOracle.price(nft);
+        (, uint256 newPrice, , ) = nftOracle.price(nft);
         assertEq(oldPrice, newPrice);
 
         // Other side
         helper.setTokenPrice(oracle, weth, uint256(1200 << 96));
         helper.setTokenPrice(oracle, wbtc, uint256(22000 << 96) * uint256(10**10));
-        (, oldPrice, ) = nftOracle.price(nft);
+        (, oldPrice, , ) = nftOracle.price(nft);
         helper.setTokenPrice(oracle, wbtc, uint256(23000 << 96) * uint256(10**10));
-        (, newPrice, ) = nftOracle.price(nft);
+        (, newPrice, , ) = nftOracle.price(nft);
         assertEq(oldPrice, newPrice);
     }
 
     function testPriceIndependentFromSpot() public {
-        (, uint256 oldPrice, ) = nftOracle.price(nft);
+        (, uint256 oldPrice, , ) = nftOracle.price(nft);
         helper.makeDesiredPoolPrice(uint256(1 << 96) / uint256(10**10 * 10), weth, wbtc);
         collectEarnings();
-        (, uint256 newPrice, ) = nftOracle.price(nft);
+        (, uint256 newPrice, , ) = nftOracle.price(nft);
         assertEq(oldPrice, newPrice);
         helper.makeDesiredPoolPrice(uint256(1 << 96) / uint256(10**10 * 18), weth, wbtc);
         collectEarnings();
-        (, newPrice, ) = nftOracle.price(nft);
+        (, newPrice, , ) = nftOracle.price(nft);
         assertEq(oldPrice, newPrice);
     }
 

--- a/test/CombinedChainlinkOracle.t.sol
+++ b/test/CombinedChainlinkOracle.t.sol
@@ -89,7 +89,7 @@ contract CombinedChainlinkOracleTest is
 
         ChainlinkOracle oracle = new ChainlinkOracle(newTokens, newOracles, heartbeats, 3600);
         UniV3Oracle nftOracle = new UniV3Oracle(PositionManager, IOracle(address(oracle)), 10**16);
-        (bool deviationSafety, , ) = nftOracle.price(tokenId);
+        (bool deviationSafety, , , ) = nftOracle.price(tokenId);
         // Checking that deviation from spot price is not bigger than 1%
         assertTrue(deviationSafety);
     }


### PR DESCRIPTION
For each pool, there is a parameter restricting minimal position width.
It is needed to liquidate positions easier because narrow positions hugely affected even by small price changes